### PR TITLE
Use ubuntu:14.04 as base instead of ubuntu:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build -t rasshofer/android-reverse-engineering .
 
-FROM ubuntu:latest
+FROM ubuntu:14.04
 MAINTAINER Thomas Rasshofer <hello@thomasrasshofer.com>
 
 ENV DEX_TOOLS_VERSION "2.0"


### PR DESCRIPTION
This fixes an issue preventing a docker build from completing successfully due to JRE 7 not present in Ubuntu 16.04's repositories.
